### PR TITLE
Integrate roo with xvfb for headless slime rl

### DIFF
--- a/roo-driver/README.md
+++ b/roo-driver/README.md
@@ -1,0 +1,60 @@
+# Roo Driver
+
+Headless-friendly VS Code extension to programmatically drive Roo Code using commands and URI handlers. Useful for RL training pipelines with xvfb.
+
+## Features
+
+- Commands:
+  - `rooDriver.startTask`: Start a new Roo task
+  - `rooDriver.sendMessage`: Send a message to the current (or specified) Roo task
+- URI endpoints (for `code --open-url`):
+  - `vscode://rl.roo-driver/start?task=...&newTab=1&stateFile=/tmp/roo-start.json`
+  - `vscode://rl.roo-driver/send?text=...&taskId=<id>&stateFile=/tmp/roo-send.json`
+
+If `stateFile` is provided, the extension writes a small JSON with `{ ok, taskId }` which you can parse from scripts.
+
+## Install
+
+1) Install Roo Code extension (from Marketplace) inside your VS Code/Code server environment.
+
+2) Build and install Roo Driver:
+
+```bash
+cd roo-driver
+npm install
+npm run compile
+# Then either run from source or package and install with vsce if desired
+```
+
+## Headless usage with xvfb
+
+Run VS Code under a virtual framebuffer and use `--open-url` to trigger actions:
+
+```bash
+xvfb-run -a code --new-window /workspace
+
+# Start a Roo task via URI (the VS Code instance can be already running or will be spawned)
+xvfb-run -a code --open-url "vscode://rl.roo-driver/start?task=$(printf %s "在 src/utils.ts 实现 xx 并补测" | jq -sRr @uri)&newTab=1&stateFile=/tmp/roo-start.json"
+
+# Send a follow-up message (optionally provide taskId; otherwise last task is used)
+xvfb-run -a code --open-url "vscode://rl.roo-driver/send?text=$(printf %s "继续到单测阶段" | jq -sRr @uri)&stateFile=/tmp/roo-send.json"
+```
+
+Tip: If `jq` is not available, use Python for URL encoding:
+
+```bash
+python3 - <<'PY'
+import sys, urllib.parse
+print(urllib.parse.quote(sys.argv[1]))
+PY "要编码的文本"
+```
+
+## Shell bridge
+
+See `../scripts/rl-bridge.sh` for a tiny CLI wrapper usable from RL pipelines.
+
+## Notes
+
+- The extension tries both `RooVeterinaryInc.roo-cline` and `RooVeterinaryInc.roo-code` as the Roo extension id.
+- There is a known timing issue when sending immediately after creating a task; a small retry is built in.
+

--- a/roo-driver/package.json
+++ b/roo-driver/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "roo-driver",
+  "displayName": "Roo Driver",
+  "description": "Headless driver for Roo Code via commands and URI handlers (ideal for RL/xvfb)",
+  "version": "0.0.1",
+  "publisher": "rl",
+  "license": "MIT",
+  "engines": {
+    "vscode": "^1.90.0"
+  },
+  "categories": [
+    "Other"
+  ],
+  "main": "./dist/extension.js",
+  "activationEvents": [
+    "onCommand:rooDriver.startTask",
+    "onCommand:rooDriver.sendMessage",
+    "onUri"
+  ],
+  "contributes": {
+    "commands": [
+      {
+        "command": "rooDriver.startTask",
+        "title": "Roo Driver: Start Task"
+      },
+      {
+        "command": "rooDriver.sendMessage",
+        "title": "Roo Driver: Send Message"
+      }
+    ]
+  },
+  "scripts": {
+    "compile": "tsc -p .",
+    "watch": "tsc -w -p ."
+  },
+  "dependencies": {
+    "@roo-code/types": "latest"
+  },
+  "devDependencies": {
+    "@types/node": "^20.12.7",
+    "@types/vscode": "^1.90.0",
+    "typescript": "^5.4.5"
+  }
+}

--- a/roo-driver/src/extension.ts
+++ b/roo-driver/src/extension.ts
@@ -1,0 +1,150 @@
+import * as vscode from 'vscode';
+import * as fs from 'node:fs/promises';
+// If you have @roo-code/types installed, you can import the types. The runtime will work regardless.
+// import type { RooCodeAPI } from '@roo-code/types';
+
+type RooCodeAPI = any; // Fallback typing to avoid hard dependency at compile time
+
+const ROO_EXTENSION_IDS = [
+    'RooVeterinaryInc.roo-cline',
+    'RooVeterinaryInc.roo-code'
+];
+
+const LAST_TASK_ID_KEY = 'rooDriver.lastTaskId';
+
+async function getRooApi(): Promise<RooCodeAPI> {
+    for (const id of ROO_EXTENSION_IDS) {
+        const ext = vscode.extensions.getExtension<RooCodeAPI>(id);
+        if (ext) {
+            await ext.activate();
+            return ext.exports as RooCodeAPI;
+        }
+    }
+    throw new Error('Roo Code extension not found. Please install Roo Code (RooVeterinaryInc.roo-code).');
+}
+
+async function startRooTask(api: RooCodeAPI, taskText: string, newTab: boolean | undefined): Promise<string | undefined> {
+    const result = await api.startNewTask({ task: taskText, newTab: Boolean(newTab) });
+    const taskId: string | undefined = result?.id ?? result?.taskId ?? result?.data?.id;
+    return taskId;
+}
+
+async function sendRooMessage(api: RooCodeAPI, text: string, taskId?: string): Promise<void> {
+    // Known Roo issue: immediate send after start may race; do a light retry.
+    const maxAttempts = 3;
+    const delayMs = 500;
+    let attempt = 0;
+    while (true) {
+        try {
+            await api.sendMessage(text, taskId ? { taskId } : undefined);
+            return;
+        } catch (err) {
+            attempt++;
+            if (attempt >= maxAttempts) {
+                throw err;
+            }
+            await new Promise((r) => setTimeout(r, delayMs));
+        }
+    }
+}
+
+export async function activate(context: vscode.ExtensionContext) {
+    const output = vscode.window.createOutputChannel('Roo Driver');
+
+    const startTaskCmd = vscode.commands.registerCommand('rooDriver.startTask', async (arg?: unknown) => {
+        const api = await getRooApi();
+        let taskText: string | undefined;
+        let newTab: boolean | undefined;
+
+        if (typeof arg === 'string') {
+            taskText = arg;
+        } else if (arg && typeof arg === 'object') {
+            const obj = arg as { task?: string; newTab?: boolean };
+            taskText = obj.task;
+            newTab = obj.newTab;
+        }
+
+        if (!taskText) {
+            taskText = await vscode.window.showInputBox({ prompt: 'Enter task for Roo' });
+            if (!taskText) {
+                return;
+            }
+        }
+
+        const taskId = await startRooTask(api, taskText, newTab);
+        if (taskId) {
+            await context.globalState.update(LAST_TASK_ID_KEY, taskId);
+            output.appendLine(`Started Roo task: ${taskId}`);
+        } else {
+            output.appendLine('Started Roo task (no taskId returned)');
+        }
+        return taskId;
+    });
+
+    const sendMessageCmd = vscode.commands.registerCommand('rooDriver.sendMessage', async (arg?: unknown) => {
+        const api = await getRooApi();
+        let text: string | undefined;
+        let taskId: string | undefined;
+        if (typeof arg === 'string') {
+            text = arg;
+        } else if (arg && typeof arg === 'object') {
+            const obj = arg as { text?: string; taskId?: string };
+            text = obj.text;
+            taskId = obj.taskId;
+        }
+        if (!text) {
+            text = await vscode.window.showInputBox({ prompt: 'Enter message to send to Roo' });
+            if (!text) {
+                return;
+            }
+        }
+        if (!taskId) {
+            taskId = context.globalState.get<string>(LAST_TASK_ID_KEY);
+        }
+        await sendRooMessage(api, text, taskId);
+        output.appendLine(`Sent message to Roo${taskId ? ` (task ${taskId})` : ''}: ${text}`);
+    });
+
+    const uriHandler: vscode.UriHandler = {
+        handleUri: async (uri: vscode.Uri) => {
+            try {
+                const api = await getRooApi();
+                const params = new URLSearchParams(uri.query);
+                const route = uri.path.replace(/^\//, '');
+                const stateFile = params.get('stateFile') || undefined;
+
+                if (route === 'start') {
+                    const task = params.get('task') ?? '';
+                    const newTab = params.get('newTab') === '1' || params.get('newTab') === 'true';
+                    const taskId = await startRooTask(api, task, newTab);
+                    if (taskId) {
+                        await context.globalState.update(LAST_TASK_ID_KEY, taskId);
+                    }
+                    if (stateFile) {
+                        await fs.writeFile(stateFile, JSON.stringify({ ok: true, taskId }, null, 2));
+                    }
+                } else if (route === 'send') {
+                    const text = params.get('text') ?? '';
+                    let taskId = params.get('taskId') || undefined;
+                    if (!taskId) {
+                        taskId = context.globalState.get<string>(LAST_TASK_ID_KEY);
+                    }
+                    await sendRooMessage(api, text, taskId);
+                    if (stateFile) {
+                        await fs.writeFile(stateFile, JSON.stringify({ ok: true, taskId }, null, 2));
+                    }
+                } else {
+                    vscode.window.showWarningMessage(`Unknown roo-driver route: ${route}`);
+                }
+            } catch (err: any) {
+                const message = err?.message ?? String(err);
+                vscode.window.showErrorMessage(`roo-driver error: ${message}`);
+            }
+        }
+    };
+
+    context.subscriptions.push(startTaskCmd, sendMessageCmd, vscode.window.registerUriHandler(uriHandler));
+}
+
+export function deactivate() {}
+

--- a/roo-driver/tsconfig.json
+++ b/roo-driver/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "lib": ["ES2022"],
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "sourceMap": true,
+    "types": ["vscode", "node"]
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/scripts/rl-bridge.sh
+++ b/scripts/rl-bridge.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Simple bridge to trigger roo-driver via VS Code's URI handler.
+# Usage:
+#   rl-bridge.sh start "task text" [--new-tab] [--state-file /tmp/roo-start.json]
+#   rl-bridge.sh send  "message"   [--task-id <id>] [--state-file /tmp/roo-send.json]
+
+CODE_BIN=${CODE_BIN:-code}
+
+urlencode() {
+	python3 - "$1" <<'PY'
+import sys, urllib.parse
+print(urllib.parse.quote(sys.argv[1]))
+PY
+}
+
+die() { echo "[rl-bridge] $*" >&2; exit 1; }
+
+cmd=${1:-}
+shift || true
+
+case "$cmd" in
+	start)
+		text=${1:-}
+		shift || true
+		new_tab=0
+		state_file=""
+		while [[ $# -gt 0 ]]; do
+			case "$1" in
+				--new-tab) new_tab=1; shift ;;
+				--state-file) state_file=${2:-}; shift 2 ;;
+				*) die "Unknown arg: $1" ;;
+			esac
+		done
+		[[ -n "$text" ]] || die "Missing task text"
+		enc_text=$(urlencode "$text")
+		uri="vscode://rl.roo-driver/start?task=${enc_text}&newTab=${new_tab}"
+		if [[ -n "$state_file" ]]; then
+			uri+="&stateFile=$(urlencode "$state_file")"
+		fi
+		exec "$CODE_BIN" --open-url "$uri"
+		;;
+	send)
+		text=${1:-}
+		shift || true
+		task_id=""
+		state_file=""
+		while [[ $# -gt 0 ]]; do
+			case "$1" in
+				--task-id) task_id=${2:-}; shift 2 ;;
+				--state-file) state_file=${2:-}; shift 2 ;;
+				*) die "Unknown arg: $1" ;;
+			esac
+		done
+		[[ -n "$text" ]] || die "Missing message text"
+		enc_text=$(urlencode "$text")
+		uri="vscode://rl.roo-driver/send?text=${enc_text}"
+		if [[ -n "$task_id" ]]; then
+			uri+="&taskId=$(urlencode "$task_id")"
+		fi
+		if [[ -n "$state_file" ]]; then
+			uri+="&stateFile=$(urlencode "$state_file")"
+		fi
+		exec "$CODE_BIN" --open-url "$uri"
+		;;
+	*)
+		die "Usage: $0 {start|send} ..."
+		;;
+esac
+


### PR DESCRIPTION
### Related GitHub Issue

Closes: # <!-- Replace with the issue number, e.g., Closes: #123 -->

### Roo Code Task Context (Optional)

### Description

This PR introduces a new VS Code extension, `roo-driver`, and a companion shell script, `scripts/rl-bridge.sh`. The primary goal is to enable headless control of the Roo Code extension, making it suitable for integration into reinforcement learning (RL) training pipelines that utilize `xvfb`.

**Key Implementation Details:**

*   **`roo-driver` Extension**:
    *   Exposes two commands: `rooDriver.startTask` and `rooDriver.sendMessage`.
    *   Registers URI handlers (`vscode://rl.roo-driver/start` and `vscode://rl.roo-driver/send`) to allow external processes (like `code --open-url`) to trigger Roo actions.
    *   Utilizes Roo's official `extension.exports` API (`startNewTask`, `sendMessage`) for programmatic interaction.
    *   Includes a retry mechanism for `sendMessage` to mitigate a known timing issue when sending messages immediately after task creation.
    *   Supports writing execution results (e.g., `taskId`) to a specified `stateFile` for easy parsing by external scripts.
*   **`scripts/rl-bridge.sh`**:
    *   A simple shell wrapper to facilitate calling the `roo-driver` URI endpoints from a command line, handling URL encoding for parameters.

This setup allows an RL agent running in a headless environment (e.g., `xvfb`) to programmatically interact with Roo Code, starting tasks and sending messages, without requiring direct UI interaction.

### Test Procedure

To test these changes, ensure you have VS Code and the Roo Code extension installed in an environment where `xvfb-run` is available.

1.  **Build and Install `roo-driver`**:
    ```bash
    cd roo-driver
    npm install
    npm run compile
    # (Optional: Package with vsce and install, or run from source)
    ```
2.  **Start VS Code Headlessly**:
    ```bash
    xvfb-run -a code --new-window /workspace
    ```
3.  **Start a Roo Task via URI**:
    ```bash
    /workspace/scripts/rl-bridge.sh start "在 src/utils.ts 实现 xx 并补测" --new-tab --state-file /tmp/roo-start.json
    ```
    Verify that `/tmp/roo-start.json` is created and contains `{ "ok": true, "taskId": "..." }`.
4.  **Send a Message to the Task via URI**:
    ```bash
    /workspace/scripts/rl-bridge.sh send "继续到单测阶段" --state-file /tmp/roo-send.json --task-id $(jq -r .taskId /tmp/roo-start.json)
    ```
    Verify that `/tmp/roo-send.json` is created and contains `{ "ok": true, "taskId": "..." }`.
    You can also omit `--task-id` to send to the last active task (as stored by the extension).

Observe the VS Code instance (if you can attach a VNC viewer or similar) to confirm Roo tasks are started and messages are sent. The `roo-driver` output channel in VS Code will also log actions.

### Pre-Submission Checklist

-   [ ] **Issue Linked**: This PR is linked to an approved GitHub Issue (see "Related GitHub Issue" above).
-   [ ] **Scope**: My changes are focused on the linked issue (one major feature/fix per PR).
-   [ ] **Self-Review**: I have performed a thorough self-review of my code.
-   [ ] **Testing**: New and/or updated tests have been added to cover my changes (if applicable).
-   [ ] **Documentation Impact**: I have considered if my changes require documentation updates (see "Documentation Updates" section below).
-   [ ] **Contribution Guidelines**: I have read and agree to the [Contributor Guidelines](/CONTRIBUTING.md).

### Screenshots / Videos

N/A (Headless driver)

### Documentation Updates

-   [ ] No documentation updates are required.
-   [x] Yes, documentation updates are required.
    *   A new `roo-driver/README.md` has been added, detailing installation, headless usage with `xvfb`, and the shell bridge.

### Additional Notes

*   The `roo-driver` extension attempts to find Roo using multiple extension IDs (`RooVeterinaryInc.roo-cline`, `RooVeterinaryInc.roo-code`) for broader compatibility.
*   The built-in retry logic for `sendMessage` addresses a known race condition when sending messages immediately after a new task is started.

### Get in Touch

<!-- Please provide your Discord username for reviewers or maintainers to reach you if they have questions about your PR -->

---
<a href="https://cursor.com/background-agent?bcId=bc-cb126dc0-9611-4de3-8609-fc5f47e4e30c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-cb126dc0-9611-4de3-8609-fc5f47e4e30c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

